### PR TITLE
fix(InviteFriends): Remove invite friends feature when platform is Windows

### DIFF
--- a/js/tabs/schedule/FriendsListView.js
+++ b/js/tabs/schedule/FriendsListView.js
@@ -30,6 +30,7 @@ var SessionsSectionHeader = require('./SessionsSectionHeader');
 var InviteFriendsButton = require('./InviteFriendsButton');
 var PureListView = require('../../common/PureListView');
 var FriendCell = require('./FriendCell');
+var Platform = require('Platform');
 
 type Friend = any;
 
@@ -92,6 +93,10 @@ class FriendsListView extends React.Component {
   }
 
   renderFooter() {
+    if (Platform.OS === 'windows') {
+      return null;
+    }
+    
     return <InviteFriendsButton style={{margin: 20}} />;
   }
 


### PR DESCRIPTION
The Windows FBSDK does not have an invite friends feature, so removing same feature from Windows F8 app.

Fixes #37
